### PR TITLE
Hide titlebar buttons in accessory mode

### DIFF
--- a/lg_remote_gui.py
+++ b/lg_remote_gui.py
@@ -483,10 +483,10 @@ class AppDelegate(NSObject):
         return self
 
     def applicationDidFinishLaunching_(self, notification):
-        # Titled + Closable + NonactivatingPanel required for policy 2 visibility
+        # Titled + NonactivatingPanel required for policy 2 visibility
+        # (Borderless + policy 2 = invisible window)
         style = (
             AppKit.NSWindowStyleMaskTitled
-            | AppKit.NSWindowStyleMaskClosable
             | NSWindowStyleMaskNonactivatingPanel
         )
         self.panel = RemotePanel.alloc().initWithContentRect_styleMask_backing_defer_(
@@ -498,6 +498,11 @@ class AppDelegate(NSObject):
         self.panel.setTitle_("")
         self.panel.setTitlebarAppearsTransparent_(True)
         self.panel.setTitleVisibility_(1)  # hidden
+        # Hide traffic-light buttons (they don't work in accessory mode anyway)
+        for btn_type in [AppKit.NSWindowCloseButton, AppKit.NSWindowMiniaturizeButton, AppKit.NSWindowZoomButton]:
+            btn = self.panel.standardWindowButton_(btn_type)
+            if btn:
+                btn.setHidden_(True)
         self.panel.setLevel_(NSFloatingWindowLevel)
         self.panel.setAlphaValue_(0.95)
         self.panel.setOpaque_(False)


### PR DESCRIPTION
## Summary
- Remove non-functional close/minimize/zoom buttons from the remote window
- Keep `NSWindowStyleMaskTitled` (required for policy 2 rendering), just hide the buttons via `standardWindowButton_`
- Drop `NSWindowStyleMaskClosable` since close doesn't work in accessory mode

## Test plan
- [x] Remote renders without traffic-light buttons
- [x] Window still draggable, Q still quits

Closes #4