### PR TITLE
Add trackpad pointer control to GUI remote

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY lg_remote.py lg_remote_web.py ./
+EXPOSE 8888
+CMD ["python3", "-u", "lg_remote_web.py"]

--- a/lg_remote.py
+++ b/lg_remote.py
@@ -214,18 +214,40 @@ class WebSocketInputClient:
         if "101" not in resp:
             raise ConnectionError(f"Input socket upgrade failed: {resp[:100]}")
 
-    def send_button(self, button_name):
-        msg = f"type:button\nname:{button_name}\n\n"
+    def _send_raw(self, msg):
+        """Send a raw text message over the WebSocket."""
         payload = msg.encode()
         frame = bytearray([0x81])
         mask_key = os.urandom(4)
         length = len(payload)
-        frame.append(0x80 | length)
+        if length < 126:
+            frame.append(0x80 | length)
+        elif length < 65536:
+            frame.append(0x80 | 126)
+            frame.extend(length.to_bytes(2, "big"))
+        else:
+            frame.append(0x80 | 127)
+            frame.extend(length.to_bytes(8, "big"))
         frame.extend(mask_key)
         frame.extend(
             bytearray(b ^ mask_key[i % 4] for i, b in enumerate(payload))
         )
         self.sock.send(frame)
+
+    def send_button(self, button_name):
+        self._send_raw(f"type:button\nname:{button_name}\n\n")
+
+    def send_move(self, dx, dy, drag=0):
+        """Send pointer move. dx/dy are relative pixel deltas."""
+        self._send_raw(f"type:move\ndx:{dx}\ndy:{dy}\ndrag:{drag}\n\n")
+
+    def send_click(self):
+        """Send pointer click at current position."""
+        self._send_raw(f"type:click\n\n")
+
+    def send_scroll(self, dx, dy):
+        """Send scroll event. dy>0 = scroll down, dy<0 = scroll up."""
+        self._send_raw(f"type:scroll\ndx:{dx}\ndy:{dy}\n\n")
 
     def send_ping(self):
         """Send a WebSocket ping frame. Raises on dead connection."""

--- a/lg_remote_gui.py
+++ b/lg_remote_gui.py
@@ -154,26 +154,12 @@ class RemoteView(NSView):
         self.activeButton = ""
         self.flashTimer = None
         self.dragOrigin = None
-        self.trackpadActive = False  # True while dragging inside trackpad zone
-        self.trackpadHover = False   # True while cursor is inside trackpad zone
-        self.onPointerMove = None    # callback(dx, dy)
-        self.onPointerClick = None   # callback()
-        self.onPointerScroll = None  # callback(dx, dy)
-        # Set up tracking area for mouse moved events in trackpad zone
-        self._setupTrackingArea()
+        self.trackpadSelected = False  # Modal: True when trackpad mode is active
+        self.onPointerMove = None      # callback(dx, dy)
+        self.onPointerClick = None     # callback()
+        self.onPointerScroll = None    # callback(dx, dy)
+        self.onTrackpadToggle = None   # callback(bool) — notify delegate of mode change
         return self
-
-    def _setupTrackingArea(self):
-        trackpad_rect = NSMakeRect(TRACKPAD_X, TRACKPAD_Y, TRACKPAD_W, TRACKPAD_H)
-        opts = (
-            AppKit.NSTrackingMouseEnteredAndExited
-            | AppKit.NSTrackingMouseMoved
-            | AppKit.NSTrackingActiveInKeyWindow
-        )
-        area = AppKit.NSTrackingArea.alloc().initWithRect_options_owner_userInfo_(
-            trackpad_rect, opts, self, None
-        )
-        self.addTrackingArea_(area)
 
     def isFlipped(self):
         return True
@@ -459,32 +445,48 @@ class RemoteView(NSView):
         rect = NSMakeRect(TRACKPAD_X, TRACKPAD_Y, TRACKPAD_W, TRACKPAD_H)
         path = NSBezierPath.bezierPathWithRoundedRect_xRadius_yRadius_(rect, 12, 12)
 
-        if self.trackpadActive:
+        if self.trackpadSelected:
             make_color_t(COLOR_TRACKPAD_ACTIVE).set()
         else:
             make_color_t(COLOR_TRACKPAD_BG).set()
         path.fill()
 
-        make_color_t(COLOR_TRACKPAD_BORDER).set()
-        path.setLineWidth_(1.0)
+        # Highlighted border when selected
+        if self.trackpadSelected:
+            make_color_t(COLOR_ACCENT_BLUE).set()
+            path.setLineWidth_(2.0)
+        else:
+            make_color_t(COLOR_TRACKPAD_BORDER).set()
+            path.setLineWidth_(1.0)
         path.stroke()
 
-        # Label
-        label_color = make_color_t(COLOR_TEXT_DIM)
-        if self.trackpadActive:
-            label_color = make_color_t(COLOR_ACCENT_BLUE)
-        self.draw_label("Trackpad", TRACKPAD_X, TRACKPAD_Y + 4, TRACKPAD_W, 14,
-                        size=9, color=label_color)
-        # Cursor icon hint
-        self.draw_label("⇢", TRACKPAD_X, TRACKPAD_Y + TRACKPAD_H / 2 - 10,
-                        TRACKPAD_W, 20, size=16, color=make_color_t(COLOR_TEXT_DIM))
+        if self.trackpadSelected:
+            self.draw_label("Pointer Active", TRACKPAD_X, TRACKPAD_Y + 4, TRACKPAD_W, 14,
+                            size=9, bold=True, color=make_color_t(COLOR_ACCENT_BLUE))
+            self.draw_label("ESC to exit", TRACKPAD_X, TRACKPAD_Y + TRACKPAD_H - 18,
+                            TRACKPAD_W, 14, size=8, color=make_color_t(COLOR_TEXT_DIM))
+            # Pointer icon
+            self.draw_label("\u25C7", TRACKPAD_X, TRACKPAD_Y + TRACKPAD_H / 2 - 12,
+                            TRACKPAD_W, 20, size=18, color=make_color_t(COLOR_ACCENT_BLUE))
+        else:
+            self.draw_label("Trackpad", TRACKPAD_X, TRACKPAD_Y + 4, TRACKPAD_W, 14,
+                            size=9, color=make_color_t(COLOR_TEXT_DIM))
+            self.draw_label("\u25C7", TRACKPAD_X, TRACKPAD_Y + TRACKPAD_H / 2 - 12,
+                            TRACKPAD_W, 20, size=18, color=make_color_t(COLOR_TEXT_DIM))
+            self.draw_label("Click to select", TRACKPAD_X, TRACKPAD_Y + TRACKPAD_H - 18,
+                            TRACKPAD_W, 14, size=8, color=make_color_t(COLOR_TEXT_DIM))
 
     # -- Footer --
 
     def draw_footer(self):
-        self.draw_label("Q/Esc close · Click trackpad to select",
-                        0, WINDOW_HEIGHT - 28, WINDOW_WIDTH, 16,
-                        size=8, color=make_color_t(COLOR_TEXT_DIM))
+        if self.trackpadSelected:
+            self.draw_label("Move to aim · Click to select · Esc exits",
+                            0, WINDOW_HEIGHT - 28, WINDOW_WIDTH, 16,
+                            size=8, color=make_color_t(COLOR_ACCENT_BLUE))
+        else:
+            self.draw_label("Q/Esc close · Click trackpad for pointer",
+                            0, WINDOW_HEIGHT - 28, WINDOW_WIDTH, 16,
+                            size=8, color=make_color_t(COLOR_TEXT_DIM))
 
     # -- Flash indicator --
 
@@ -538,29 +540,44 @@ class RemoteView(NSView):
         return (TRACKPAD_X <= loc.x <= TRACKPAD_X + TRACKPAD_W and
                 TRACKPAD_Y <= loc.y <= TRACKPAD_Y + TRACKPAD_H)
 
+    def enterTrackpadMode(self):
+        """Enter modal trackpad pointer mode."""
+        self.trackpadSelected = True
+        if self.onTrackpadToggle:
+            self.onTrackpadToggle(True)
+        self.setNeedsDisplay_(True)
+
+    def exitTrackpadMode(self):
+        """Exit modal trackpad pointer mode."""
+        self.trackpadSelected = False
+        if self.onTrackpadToggle:
+            self.onTrackpadToggle(False)
+        self.setNeedsDisplay_(True)
+
     def mouseDown_(self, event):
         # Activate the app so local key monitor works
         NSApp.activateIgnoringOtherApps_(True)
         self.window().makeKeyWindow()
 
+        if self.trackpadSelected:
+            # While in trackpad mode, click = TV click
+            if self.onPointerClick:
+                self.onPointerClick()
+            return
+
         if self._point_in_trackpad(event):
-            # Start trackpad pointer mode
-            self.trackpadActive = True
-            self.trackpadDragged = False
-            self.dragOrigin = None
-            self.setNeedsDisplay_(True)
+            # Click on trackpad zone → enter pointer mode
+            self.enterTrackpadMode()
         else:
             # Window drag mode
-            self.trackpadActive = False
             self.dragOrigin = event.locationInWindow()
 
     def mouseDragged_(self, event):
-        if self.trackpadActive:
-            # Send pointer move with raw deltas — apply sensitivity curve
+        if self.trackpadSelected:
+            # In trackpad mode, drags also move the pointer
             dx, dy = apply_sensitivity(event.deltaX(), event.deltaY())
             if self.onPointerMove and (dx or dy):
                 self.onPointerMove(dx, dy)
-                self.trackpadDragged = True
             return
 
         # Window drag
@@ -575,30 +592,8 @@ class RemoteView(NSView):
         window.setFrameOrigin_(new_origin)
 
     def mouseUp_(self, event):
-        if self.trackpadActive:
-            # Only click if we didn't drag (tap = click, drag = move)
-            if not self.trackpadDragged and self.onPointerClick:
-                self.onPointerClick()
-            self.trackpadActive = False
-            self.trackpadDragged = False
-            self.setNeedsDisplay_(True)
-            return
-        self.dragOrigin = None
-
-    def mouseEntered_(self, event):
-        self.trackpadHover = True
-        self.setNeedsDisplay_(True)
-
-    def mouseExited_(self, event):
-        self.trackpadHover = False
-        self.setNeedsDisplay_(True)
-
-    def scrollWheel_(self, event):
-        if self._point_in_trackpad(event) and self.onPointerScroll:
-            dx = int(event.scrollingDeltaX())
-            dy = int(event.scrollingDeltaY())
-            if dx or dy:
-                self.onPointerScroll(dx, dy)
+        if not self.trackpadSelected:
+            self.dragOrigin = None
 
 
 class AppDelegate(NSObject):
@@ -610,6 +605,7 @@ class AppDelegate(NSObject):
         self.remote_view = None
         self.reconnecting = False
         self.keepalive_active = False
+        self._moveMonitor = None
         return self
 
     def applicationDidFinishLaunching_(self, notification):
@@ -653,6 +649,9 @@ class AppDelegate(NSObject):
         self.panel.setContentView_(self.remote_view)
         self.panel.setDelegate_(self)
         self.panel.makeKeyAndOrderFront_(None)
+
+        # Wire trackpad mode toggle
+        self.remote_view.onTrackpadToggle = self.handle_trackpad_toggle
 
         # Local key monitor ONLY — keys only captured when remote is focused
         NSEvent.addLocalMonitorForEventsMatchingMask_handler_(
@@ -764,6 +763,32 @@ class AppDelegate(NSObject):
                 self.remote_view.update_status("Connection lost", False)
                 threading.Thread(target=self.reconnect_tv, daemon=True).start()
 
+    def handle_trackpad_toggle(self, entering):
+        """Called when trackpad mode is entered/exited."""
+        if entering:
+            # Start monitoring mouse-moved + scroll events
+            def handler(event):
+                if event.type() == AppKit.NSScrollWheel:
+                    dx = int(event.scrollingDeltaX())
+                    dy = int(event.scrollingDeltaY())
+                    if dx or dy:
+                        self.send_pointer_scroll(dx, dy)
+                    return event
+                # Mouse moved
+                dx, dy = apply_sensitivity(event.deltaX(), event.deltaY())
+                if dx or dy:
+                    self.send_pointer_move(dx, dy)
+                return event
+
+            self._moveMonitor = NSEvent.addLocalMonitorForEventsMatchingMask_handler_(
+                AppKit.NSMouseMovedMask | AppKit.NSScrollWheelMask,
+                handler
+            )
+        else:
+            if self._moveMonitor:
+                NSEvent.removeMonitor_(self._moveMonitor)
+                self._moveMonitor = None
+
     def send_pointer_scroll(self, dx, dy):
         if self.input_ws:
             try:
@@ -782,9 +807,22 @@ class AppDelegate(NSObject):
         """Local monitor — only fires when remote window is focused."""
         kc = event.keyCode()
 
-        if kc == 53 or kc == 12:  # Escape or Q = quit
+        if kc == 53:  # Escape
+            if self.remote_view.trackpadSelected:
+                # Exit trackpad mode, don't quit
+                self.remote_view.exitTrackpadMode()
+                return None
+            else:
+                os._exit(0)
+                return None
+
+        if kc == 12:  # Q = always quit
             os._exit(0)
             return None
+
+        # In trackpad mode, don't process button keys (except ESC/Q above)
+        if self.remote_view.trackpadSelected:
+            return event
 
         btn = KEYCODE_MAP.get(kc)
         if btn and self.input_ws:

--- a/lg_remote_gui.py
+++ b/lg_remote_gui.py
@@ -105,27 +105,28 @@ TRACKPAD_W = WINDOW_WIDTH - 40
 TRACKPAD_H = 110
 
 
-def apply_sensitivity(raw_dx, raw_dy):
-    """Convert raw trackpad deltas to TV pointer deltas.
+class Sensitivity:
+    """Accumulates fractional deltas so small movements aren't lost to int truncation."""
+    def __init__(self, multiplier=2.0):
+        self.multiplier = multiplier
+        self.accum_x = 0.0
+        self.accum_y = 0.0
 
-    Args:
-        raw_dx: Raw horizontal delta from NSEvent.deltaX() (float, pixels)
-        raw_dy: Raw vertical delta from NSEvent.deltaY() (float, pixels)
+    def apply(self, raw_dx, raw_dy):
+        self.accum_x += raw_dx * self.multiplier
+        self.accum_y += raw_dy * self.multiplier
+        dx = int(self.accum_x)
+        dy = int(self.accum_y)
+        self.accum_x -= dx
+        self.accum_y -= dy
+        return dx, dy
 
-    Returns:
-        (int, int): Scaled dx, dy to send to the TV via send_move()
+    def reset(self):
+        self.accum_x = 0.0
+        self.accum_y = 0.0
 
-    TODO: Implement your preferred sensitivity curve. Consider:
-      - Linear (multiplier): simple, predictable — good starting point
-      - Exponential/power curve: slow for fine control, fast for big swipes
-      - Dead zone: ignore tiny movements to prevent jitter
-      - The TV screen is ~1920px wide; macOS trackpad deltas are typically 1-20 per event
-    """
-    # Linear scaling — adjust multiplier to taste
-    sensitivity = 1.5
-    dx = int(raw_dx * sensitivity)
-    dy = int(raw_dy * sensitivity)
-    return dx, dy
+
+pointer_sensitivity = Sensitivity(multiplier=2.0)
 
 
 def make_color(r, g, b, a=1.0):
@@ -576,7 +577,7 @@ class RemoteView(NSView):
     def mouseDragged_(self, event):
         if self.trackpadSelected:
             # In trackpad mode, drags also move the pointer
-            dx, dy = apply_sensitivity(event.deltaX(), event.deltaY())
+            dx, dy = pointer_sensitivity.apply(event.deltaX(), event.deltaY())
             if self.onPointerMove and (dx or dy):
                 self.onPointerMove(dx, dy)
             return
@@ -768,7 +769,8 @@ class AppDelegate(NSObject):
     def handle_trackpad_toggle(self, entering):
         """Called when trackpad mode is entered/exited."""
         if entering:
-            # Hide cursor and freeze it so it can't leave the window
+            # Reset accumulator and hide/freeze cursor
+            pointer_sensitivity.reset()
             Quartz.CGAssociateMouseAndMouseCursorPosition(False)
             AppKit.NSCursor.hide()
 
@@ -778,7 +780,7 @@ class AppDelegate(NSObject):
                 if event_type == Quartz.kCGEventMouseMoved:
                     raw_dx = Quartz.CGEventGetDoubleValueField(event, Quartz.kCGMouseEventDeltaX)
                     raw_dy = Quartz.CGEventGetDoubleValueField(event, Quartz.kCGMouseEventDeltaY)
-                    dx, dy = apply_sensitivity(raw_dx, raw_dy)
+                    dx, dy = pointer_sensitivity.apply(raw_dx, raw_dy)
                     if dx or dy:
                         self.send_pointer_move(dx, dy)
                 elif event_type == Quartz.kCGEventScrollWheel:

--- a/lg_remote_gui.py
+++ b/lg_remote_gui.py
@@ -606,7 +606,8 @@ class AppDelegate(NSObject):
         self.remote_view = None
         self.reconnecting = False
         self.keepalive_active = False
-        self._moveMonitor = None
+        self._tap = None
+        self._tapSource = None
         return self
 
     def applicationDidFinishLaunching_(self, notification):
@@ -767,34 +768,58 @@ class AppDelegate(NSObject):
     def handle_trackpad_toggle(self, entering):
         """Called when trackpad mode is entered/exited."""
         if entering:
-            # Decouple cursor from trackpad — deltas keep flowing but
-            # the Mac cursor stays put, so it never hits window edges
+            # Hide cursor and freeze it so it can't leave the window
             Quartz.CGAssociateMouseAndMouseCursorPosition(False)
             AppKit.NSCursor.hide()
 
-            # Start monitoring mouse-moved + scroll events
-            def handler(event):
-                if event.type() == AppKit.NSScrollWheel:
-                    dx = int(event.scrollingDeltaX())
-                    dy = int(event.scrollingDeltaY())
+            # Use a CGEventTap to capture raw mouse/scroll deltas — this is
+            # reliable even with the cursor dissociated, unlike NSEvent monitors
+            def tap_callback(_proxy, event_type, event, _refcon):
+                if event_type == Quartz.kCGEventMouseMoved:
+                    raw_dx = Quartz.CGEventGetDoubleValueField(event, Quartz.kCGMouseEventDeltaX)
+                    raw_dy = Quartz.CGEventGetDoubleValueField(event, Quartz.kCGMouseEventDeltaY)
+                    dx, dy = apply_sensitivity(raw_dx, raw_dy)
+                    if dx or dy:
+                        self.send_pointer_move(dx, dy)
+                elif event_type == Quartz.kCGEventScrollWheel:
+                    dx = int(Quartz.CGEventGetIntegerValueField(event, Quartz.kCGScrollWheelEventPointDeltaAxis2))
+                    dy = int(Quartz.CGEventGetIntegerValueField(event, Quartz.kCGScrollWheelEventPointDeltaAxis1))
                     if dx or dy:
                         self.send_pointer_scroll(dx, dy)
-                    return event
-                # Mouse moved — deltas are independent of cursor position
-                dx, dy = apply_sensitivity(event.deltaX(), event.deltaY())
-                if dx or dy:
-                    self.send_pointer_move(dx, dy)
                 return event
 
-            self._moveMonitor = NSEvent.addLocalMonitorForEventsMatchingMask_handler_(
-                AppKit.NSMouseMovedMask | AppKit.NSScrollWheelMask,
-                handler
+            event_mask = (
+                (1 << Quartz.kCGEventMouseMoved) |
+                (1 << Quartz.kCGEventScrollWheel)
             )
+            self._tap = Quartz.CGEventTapCreate(
+                Quartz.kCGSessionEventTap,
+                Quartz.kCGHeadInsertEventTap,
+                Quartz.kCGEventTapOptionDefault,
+                event_mask,
+                tap_callback,
+                None,
+            )
+            if self._tap:
+                self._tapSource = Quartz.CFMachPortCreateRunLoopSource(None, self._tap, 0)
+                Quartz.CFRunLoopAddSource(
+                    Quartz.CFRunLoopGetCurrent(),
+                    self._tapSource,
+                    Quartz.kCFRunLoopCommonModes,
+                )
+                Quartz.CGEventTapEnable(self._tap, True)
         else:
-            if self._moveMonitor:
-                NSEvent.removeMonitor_(self._moveMonitor)
-                self._moveMonitor = None
-            # Re-associate cursor and show it
+            # Tear down the event tap
+            if hasattr(self, '_tap') and self._tap:
+                Quartz.CGEventTapEnable(self._tap, False)
+                Quartz.CFRunLoopRemoveSource(
+                    Quartz.CFRunLoopGetCurrent(),
+                    self._tapSource,
+                    Quartz.kCFRunLoopCommonModes,
+                )
+                self._tap = None
+                self._tapSource = None
+            # Restore cursor
             Quartz.CGAssociateMouseAndMouseCursorPosition(True)
             AppKit.NSCursor.unhide()
 
@@ -855,8 +880,7 @@ class AppDelegate(NSObject):
     def applicationWillTerminate_(self, notification):
         # Restore cursor if still in trackpad mode
         if self.remote_view and self.remote_view.trackpadSelected:
-            Quartz.CGAssociateMouseAndMouseCursorPosition(True)
-            AppKit.NSCursor.unhide()
+            self.handle_trackpad_toggle(False)
         if self.input_ws:
             self.input_ws.close()
         if self.ws:

--- a/lg_remote_gui.py
+++ b/lg_remote_gui.py
@@ -10,6 +10,7 @@ import time
 
 import AppKit
 import objc
+import Quartz
 
 from AppKit import (
     NSApplication,
@@ -766,6 +767,11 @@ class AppDelegate(NSObject):
     def handle_trackpad_toggle(self, entering):
         """Called when trackpad mode is entered/exited."""
         if entering:
+            # Decouple cursor from trackpad — deltas keep flowing but
+            # the Mac cursor stays put, so it never hits window edges
+            Quartz.CGAssociateMouseAndMouseCursorPosition(False)
+            AppKit.NSCursor.hide()
+
             # Start monitoring mouse-moved + scroll events
             def handler(event):
                 if event.type() == AppKit.NSScrollWheel:
@@ -774,7 +780,7 @@ class AppDelegate(NSObject):
                     if dx or dy:
                         self.send_pointer_scroll(dx, dy)
                     return event
-                # Mouse moved
+                # Mouse moved — deltas are independent of cursor position
                 dx, dy = apply_sensitivity(event.deltaX(), event.deltaY())
                 if dx or dy:
                     self.send_pointer_move(dx, dy)
@@ -788,6 +794,9 @@ class AppDelegate(NSObject):
             if self._moveMonitor:
                 NSEvent.removeMonitor_(self._moveMonitor)
                 self._moveMonitor = None
+            # Re-associate cursor and show it
+            Quartz.CGAssociateMouseAndMouseCursorPosition(True)
+            AppKit.NSCursor.unhide()
 
     def send_pointer_scroll(self, dx, dy):
         if self.input_ws:
@@ -844,6 +853,10 @@ class AppDelegate(NSObject):
         return True
 
     def applicationWillTerminate_(self, notification):
+        # Restore cursor if still in trackpad mode
+        if self.remote_view and self.remote_view.trackpadSelected:
+            Quartz.CGAssociateMouseAndMouseCursorPosition(True)
+            AppKit.NSCursor.unhide()
         if self.input_ws:
             self.input_ws.close()
         if self.ws:

--- a/lg_remote_gui.py
+++ b/lg_remote_gui.py
@@ -72,7 +72,7 @@ KEYCODE_MAP = {
 }
 
 WINDOW_WIDTH = 220
-WINDOW_HEIGHT = 420
+WINDOW_HEIGHT = 540
 
 # -- Color palette --
 COLOR_BODY_BG = (0.10, 0.10, 0.13, 0.95)
@@ -93,6 +93,38 @@ COLOR_DPAD_ACTIVE = (0.30, 0.50, 0.90, 0.85)
 COLOR_OK_BG = (0.25, 0.25, 0.35, 0.95)
 COLOR_VOL_BG = (0.16, 0.16, 0.22, 0.9)
 COLOR_VOL_DIVIDER = (0.30, 0.30, 0.38, 0.5)
+COLOR_TRACKPAD_BG = (0.12, 0.12, 0.17, 0.9)
+COLOR_TRACKPAD_BORDER = (0.28, 0.28, 0.36, 0.6)
+COLOR_TRACKPAD_ACTIVE = (0.20, 0.35, 0.65, 0.4)
+
+# Trackpad zone geometry
+TRACKPAD_X = 20
+TRACKPAD_Y = 385
+TRACKPAD_W = WINDOW_WIDTH - 40
+TRACKPAD_H = 110
+
+
+def apply_sensitivity(raw_dx, raw_dy):
+    """Convert raw trackpad deltas to TV pointer deltas.
+
+    Args:
+        raw_dx: Raw horizontal delta from NSEvent.deltaX() (float, pixels)
+        raw_dy: Raw vertical delta from NSEvent.deltaY() (float, pixels)
+
+    Returns:
+        (int, int): Scaled dx, dy to send to the TV via send_move()
+
+    TODO: Implement your preferred sensitivity curve. Consider:
+      - Linear (multiplier): simple, predictable — good starting point
+      - Exponential/power curve: slow for fine control, fast for big swipes
+      - Dead zone: ignore tiny movements to prevent jitter
+      - The TV screen is ~1920px wide; macOS trackpad deltas are typically 1-20 per event
+    """
+    # Linear scaling — adjust multiplier to taste
+    sensitivity = 1.5
+    dx = int(raw_dx * sensitivity)
+    dy = int(raw_dy * sensitivity)
+    return dx, dy
 
 
 def make_color(r, g, b, a=1.0):
@@ -122,7 +154,26 @@ class RemoteView(NSView):
         self.activeButton = ""
         self.flashTimer = None
         self.dragOrigin = None
+        self.trackpadActive = False  # True while dragging inside trackpad zone
+        self.trackpadHover = False   # True while cursor is inside trackpad zone
+        self.onPointerMove = None    # callback(dx, dy)
+        self.onPointerClick = None   # callback()
+        self.onPointerScroll = None  # callback(dx, dy)
+        # Set up tracking area for mouse moved events in trackpad zone
+        self._setupTrackingArea()
         return self
+
+    def _setupTrackingArea(self):
+        trackpad_rect = NSMakeRect(TRACKPAD_X, TRACKPAD_Y, TRACKPAD_W, TRACKPAD_H)
+        opts = (
+            AppKit.NSTrackingMouseEnteredAndExited
+            | AppKit.NSTrackingMouseMoved
+            | AppKit.NSTrackingActiveInKeyWindow
+        )
+        area = AppKit.NSTrackingArea.alloc().initWithRect_options_owner_userInfo_(
+            trackpad_rect, opts, self, None
+        )
+        self.addTrackingArea_(area)
 
     def isFlipped(self):
         return True
@@ -143,6 +194,7 @@ class RemoteView(NSView):
         self.draw_nav_buttons()
         self.draw_volume_rocker()
         self.draw_power_button()
+        self.draw_trackpad_zone()
         self.draw_footer()
         self.draw_flash_indicator()
 
@@ -401,12 +453,38 @@ class RemoteView(NSView):
         tc = make_color(1, 1, 1, 1) if is_active else make_color_t(COLOR_ACCENT_RED)
         self.draw_label("\u23FB", px, py + 14, pw, 22, size=18, bold=True, color=tc)
 
+    # -- Trackpad zone --
+
+    def draw_trackpad_zone(self):
+        rect = NSMakeRect(TRACKPAD_X, TRACKPAD_Y, TRACKPAD_W, TRACKPAD_H)
+        path = NSBezierPath.bezierPathWithRoundedRect_xRadius_yRadius_(rect, 12, 12)
+
+        if self.trackpadActive:
+            make_color_t(COLOR_TRACKPAD_ACTIVE).set()
+        else:
+            make_color_t(COLOR_TRACKPAD_BG).set()
+        path.fill()
+
+        make_color_t(COLOR_TRACKPAD_BORDER).set()
+        path.setLineWidth_(1.0)
+        path.stroke()
+
+        # Label
+        label_color = make_color_t(COLOR_TEXT_DIM)
+        if self.trackpadActive:
+            label_color = make_color_t(COLOR_ACCENT_BLUE)
+        self.draw_label("Trackpad", TRACKPAD_X, TRACKPAD_Y + 4, TRACKPAD_W, 14,
+                        size=9, color=label_color)
+        # Cursor icon hint
+        self.draw_label("⇢", TRACKPAD_X, TRACKPAD_Y + TRACKPAD_H / 2 - 10,
+                        TRACKPAD_W, 20, size=16, color=make_color_t(COLOR_TEXT_DIM))
+
     # -- Footer --
 
     def draw_footer(self):
-        self.draw_label("Q or Esc to close",
+        self.draw_label("Q/Esc close · Click trackpad to select",
                         0, WINDOW_HEIGHT - 28, WINDOW_WIDTH, 16,
-                        size=9, color=make_color_t(COLOR_TEXT_DIM))
+                        size=8, color=make_color_t(COLOR_TEXT_DIM))
 
     # -- Flash indicator --
 
@@ -452,15 +530,40 @@ class RemoteView(NSView):
         self.statusConnected = connected
         self.setNeedsDisplay_(True)
 
-    # -- Dragging support --
+    # -- Mouse / trackpad support --
+
+    def _point_in_trackpad(self, event):
+        """Check if an event location (in flipped view coords) is in the trackpad zone."""
+        loc = self.convertPoint_fromView_(event.locationInWindow(), None)
+        return (TRACKPAD_X <= loc.x <= TRACKPAD_X + TRACKPAD_W and
+                TRACKPAD_Y <= loc.y <= TRACKPAD_Y + TRACKPAD_H)
 
     def mouseDown_(self, event):
         # Activate the app so local key monitor works
         NSApp.activateIgnoringOtherApps_(True)
         self.window().makeKeyWindow()
-        self.dragOrigin = event.locationInWindow()
+
+        if self._point_in_trackpad(event):
+            # Start trackpad pointer mode
+            self.trackpadActive = True
+            self.trackpadDragged = False
+            self.dragOrigin = None
+            self.setNeedsDisplay_(True)
+        else:
+            # Window drag mode
+            self.trackpadActive = False
+            self.dragOrigin = event.locationInWindow()
 
     def mouseDragged_(self, event):
+        if self.trackpadActive:
+            # Send pointer move with raw deltas — apply sensitivity curve
+            dx, dy = apply_sensitivity(event.deltaX(), event.deltaY())
+            if self.onPointerMove and (dx or dy):
+                self.onPointerMove(dx, dy)
+                self.trackpadDragged = True
+            return
+
+        # Window drag
         if self.dragOrigin is None:
             return
         window = self.window()
@@ -470,6 +573,32 @@ class RemoteView(NSView):
         dy = screen_loc.y - self.dragOrigin.y
         new_origin = (current_frame.origin.x + dx, current_frame.origin.y + dy)
         window.setFrameOrigin_(new_origin)
+
+    def mouseUp_(self, event):
+        if self.trackpadActive:
+            # Only click if we didn't drag (tap = click, drag = move)
+            if not self.trackpadDragged and self.onPointerClick:
+                self.onPointerClick()
+            self.trackpadActive = False
+            self.trackpadDragged = False
+            self.setNeedsDisplay_(True)
+            return
+        self.dragOrigin = None
+
+    def mouseEntered_(self, event):
+        self.trackpadHover = True
+        self.setNeedsDisplay_(True)
+
+    def mouseExited_(self, event):
+        self.trackpadHover = False
+        self.setNeedsDisplay_(True)
+
+    def scrollWheel_(self, event):
+        if self._point_in_trackpad(event) and self.onPointerScroll:
+            dx = int(event.scrollingDeltaX())
+            dy = int(event.scrollingDeltaY())
+            if dx or dy:
+                self.onPointerScroll(dx, dy)
 
 
 class AppDelegate(NSObject):
@@ -613,6 +742,35 @@ class AppDelegate(NSObject):
 
     def onConnected_(self, _):
         self.remote_view.update_status("Connected", True)
+        # Wire up trackpad pointer callbacks
+        self.remote_view.onPointerMove = self.send_pointer_move
+        self.remote_view.onPointerClick = self.send_pointer_click
+        self.remote_view.onPointerScroll = self.send_pointer_scroll
+
+    def send_pointer_move(self, dx, dy):
+        if self.input_ws:
+            try:
+                self.input_ws.send_move(dx, dy)
+            except Exception:
+                self.remote_view.update_status("Connection lost", False)
+                threading.Thread(target=self.reconnect_tv, daemon=True).start()
+
+    def send_pointer_click(self):
+        if self.input_ws:
+            try:
+                self.input_ws.send_click()
+                self.remote_view.flash_button("CLICK")
+            except Exception:
+                self.remote_view.update_status("Connection lost", False)
+                threading.Thread(target=self.reconnect_tv, daemon=True).start()
+
+    def send_pointer_scroll(self, dx, dy):
+        if self.input_ws:
+            try:
+                self.input_ws.send_scroll(dx, dy)
+            except Exception:
+                self.remote_view.update_status("Connection lost", False)
+                threading.Thread(target=self.reconnect_tv, daemon=True).start()
 
     def onConnectionError_(self, err):
         msg = str(err) if err else "Unknown error"

--- a/lg_remote_web.py
+++ b/lg_remote_web.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""LG TV Remote — web server for iPhone/mobile access."""
+
+import json
+import os
+import sys
+import threading
+import time
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from lg_remote import (
+    WebSocketClient,
+    WebSocketInputClient,
+    authenticate,
+    get_input_socket_url,
+    TV_HOST,
+    TV_PORT,
+)
+
+WEB_PORT = int(os.environ.get("WEB_PORT", "8888"))
+
+# Shared TV connection state
+tv_lock = threading.Lock()
+tv_ws = None
+tv_input = None
+tv_status = {"connected": False, "message": "Disconnected"}
+
+
+def connect_tv():
+    """Connect to TV with retry logic."""
+    global tv_ws, tv_input
+    delays = [5, 15, 30]
+    for attempt in range(len(delays) + 1):
+        try:
+            with tv_lock:
+                if tv_ws:
+                    tv_ws.close()
+                tv_ws = WebSocketClient(TV_HOST, TV_PORT)
+                tv_ws.connect()
+                authenticate(tv_ws)
+                url = get_input_socket_url(tv_ws)
+                tv_input = WebSocketInputClient(url)
+                tv_input.connect()
+                tv_status["connected"] = True
+                tv_status["message"] = "Connected"
+            print(f"Connected to TV at {TV_HOST}")
+            return
+        except Exception as e:
+            msg = str(e)
+            if "Expecting value" in msg or "JSONDecode" in msg:
+                msg = "TV sent empty response"
+            elif "no key received" in msg:
+                msg = "Auth failed"
+            if attempt < len(delays):
+                wait = delays[attempt]
+                tv_status["message"] = f"{msg} — retry in {wait}s"
+                print(f"Connection failed: {msg} — retrying in {wait}s")
+                time.sleep(wait)
+            else:
+                tv_status["message"] = f"{msg} — giving up"
+                print(f"Connection failed: {msg}")
+
+
+def keepalive_loop():
+    """Ping TV every 15s, reconnect on failure."""
+    while True:
+        time.sleep(15)
+        with tv_lock:
+            if not tv_status["connected"]:
+                continue
+            try:
+                if tv_ws:
+                    tv_ws.send_ping()
+                if tv_input:
+                    tv_input.send_ping()
+            except Exception:
+                tv_status["connected"] = False
+                tv_status["message"] = "Connection lost"
+                print("Connection lost — reconnecting...")
+                threading.Thread(target=connect_tv, daemon=True).start()
+
+
+def send_button(name):
+    """Send a button press to the TV."""
+    with tv_lock:
+        if not tv_input or not tv_status["connected"]:
+            return False, "Not connected"
+        try:
+            tv_input.send_button(name)
+            return True, "OK"
+        except Exception as e:
+            tv_status["connected"] = False
+            tv_status["message"] = "Connection lost"
+            threading.Thread(target=connect_tv, daemon=True).start()
+            return False, str(e)
+
+
+HTML_PAGE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="apple-mobile-web-app-title" content="LG Remote">
+<title>LG Remote</title>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
+html, body {
+  height: 100%; width: 100%;
+  background: #0d0d11;
+  color: #d0d0d8;
+  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro', system-ui, sans-serif;
+  overflow: hidden;
+  touch-action: manipulation;
+  user-select: none; -webkit-user-select: none;
+}
+body {
+  display: flex; flex-direction: column; align-items: center;
+  padding: env(safe-area-inset-top) 16px env(safe-area-inset-bottom);
+}
+
+/* Status bar */
+.status {
+  display: flex; align-items: center; gap: 8px;
+  padding: 12px 0 4px;
+  font-size: 13px; color: #888;
+}
+.status .dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: #d44; transition: background 0.3s;
+}
+.status.connected .dot { background: #4c4; }
+.title {
+  font-size: 20px; font-weight: 700; color: #e0e0e8;
+  padding: 4px 0 16px;
+  letter-spacing: -0.5px;
+}
+
+/* Remote container */
+.remote {
+  display: flex; flex-direction: column; align-items: center;
+  gap: 20px; width: 100%; max-width: 320px;
+  flex: 1;
+}
+
+/* D-Pad */
+.dpad {
+  position: relative;
+  width: 220px; height: 220px;
+}
+.dpad-ring {
+  position: absolute; inset: 0;
+  border-radius: 50%;
+  background: #1a1a22;
+  border: 1px solid #2a2a35;
+}
+.dpad-btn {
+  position: absolute;
+  display: flex; align-items: center; justify-content: center;
+  color: #c0c0c8; font-size: 22px;
+  cursor: pointer;
+  z-index: 2;
+  transition: color 0.1s;
+}
+.dpad-btn:active { color: #fff; }
+.dpad-up    { top: 8px;   left: 50%; transform: translateX(-50%); width: 70px; height: 60px; }
+.dpad-down  { bottom: 8px; left: 50%; transform: translateX(-50%); width: 70px; height: 60px; }
+.dpad-left  { left: 8px;  top: 50%; transform: translateY(-50%); width: 60px; height: 70px; }
+.dpad-right { right: 8px; top: 50%; transform: translateY(-50%); width: 60px; height: 70px; }
+.dpad-ok {
+  position: absolute;
+  top: 50%; left: 50%; transform: translate(-50%, -50%);
+  width: 72px; height: 72px; border-radius: 50%;
+  background: #222233;
+  border: 1px solid #333345;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 15px; font-weight: 600; color: #d0d0d8;
+  cursor: pointer; z-index: 3;
+  transition: background 0.1s;
+}
+.dpad-ok:active { background: #3355aa; color: #fff; }
+
+/* Touch highlight for d-pad arrows */
+.dpad-btn:active::after {
+  content: '';
+  position: absolute; inset: 0;
+  border-radius: 50%;
+  background: rgba(60, 100, 200, 0.25);
+}
+
+/* Nav row */
+.nav-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  width: 100%; max-width: 260px;
+}
+.nav-btn {
+  height: 44px; border-radius: 22px;
+  background: #1e1e28;
+  border: 1px solid #2a2a35;
+  color: #c0c0c8;
+  font-size: 14px; font-weight: 500;
+  cursor: pointer;
+  transition: background 0.1s;
+  display: flex; align-items: center; justify-content: center;
+}
+.nav-btn:active { background: #3355aa; color: #fff; }
+
+/* Bottom controls */
+.bottom-row {
+  display: flex; align-items: center; justify-content: space-between;
+  width: 100%; max-width: 280px;
+  gap: 16px;
+}
+
+/* Volume rocker */
+.vol-rocker {
+  display: flex; flex-direction: column;
+  border-radius: 28px;
+  background: #1a1a22;
+  border: 1px solid #2a2a35;
+  overflow: hidden;
+  width: 60px;
+}
+.vol-btn {
+  height: 52px;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 22px; font-weight: 600; color: #c0c0c8;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+.vol-btn:active { background: #3355aa; color: #fff; }
+.vol-divider {
+  height: 1px; background: #2a2a35; margin: 0 8px;
+}
+
+/* Mute */
+.mute-btn {
+  width: 60px; height: 36px; border-radius: 18px;
+  background: #1e1e28; border: 1px solid #2a2a35;
+  color: #c0c0c8; font-size: 12px; font-weight: 500;
+  cursor: pointer; display: flex; align-items: center; justify-content: center;
+  transition: background 0.1s;
+}
+.mute-btn:active { background: #3355aa; color: #fff; }
+
+/* Power */
+.power-btn {
+  width: 56px; height: 56px; border-radius: 50%;
+  background: #3a1515;
+  border: 2px solid #5a2020;
+  color: #e04040;
+  font-size: 24px;
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: background 0.1s;
+}
+.power-btn:active { background: #c02020; color: #fff; }
+
+/* Channel rocker */
+.ch-rocker {
+  display: flex; flex-direction: column;
+  border-radius: 28px;
+  background: #1a1a22;
+  border: 1px solid #2a2a35;
+  overflow: hidden;
+  width: 60px;
+}
+.ch-btn {
+  height: 52px;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 13px; font-weight: 600; color: #c0c0c8;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+.ch-btn:active { background: #3355aa; color: #fff; }
+
+/* Feedback toast */
+.toast {
+  position: fixed; bottom: 40px; left: 50%; transform: translateX(-50%);
+  background: rgba(50, 80, 180, 0.85);
+  color: #fff; font-size: 13px; font-weight: 600;
+  padding: 6px 18px; border-radius: 20px;
+  opacity: 0; transition: opacity 0.15s;
+  pointer-events: none;
+}
+.toast.show { opacity: 1; }
+
+/* Haptic feedback visual */
+@keyframes press {
+  0% { transform: scale(1); }
+  50% { transform: scale(0.92); }
+  100% { transform: scale(1); }
+}
+.pressing { animation: press 0.15s ease; }
+</style>
+</head>
+<body>
+
+<div class="status" id="status">
+  <div class="dot"></div>
+  <span id="status-text">Connecting...</span>
+</div>
+<div class="title">LG Remote</div>
+
+<div class="remote">
+  <!-- D-Pad -->
+  <div class="dpad">
+    <div class="dpad-ring"></div>
+    <div class="dpad-btn dpad-up" data-btn="UP">&#9650;</div>
+    <div class="dpad-btn dpad-down" data-btn="DOWN">&#9660;</div>
+    <div class="dpad-btn dpad-left" data-btn="LEFT">&#9664;</div>
+    <div class="dpad-btn dpad-right" data-btn="RIGHT">&#9654;</div>
+    <div class="dpad-ok" data-btn="ENTER">OK</div>
+  </div>
+
+  <!-- Nav buttons -->
+  <div class="nav-row">
+    <div class="nav-btn" data-btn="MENU">Menu</div>
+    <div class="nav-btn" data-btn="BACK">Back</div>
+    <div class="nav-btn" data-btn="HOME">Home</div>
+    <div class="nav-btn" data-btn="INFO">Info</div>
+  </div>
+
+  <!-- Bottom: Volume, Power, Channels -->
+  <div class="bottom-row">
+    <div style="display:flex;flex-direction:column;align-items:center;gap:8px;">
+      <div class="vol-rocker">
+        <div class="vol-btn" data-btn="VOLUMEUP">+</div>
+        <div class="vol-divider"></div>
+        <div class="vol-btn" data-btn="VOLUMEDOWN">&minus;</div>
+      </div>
+      <div class="mute-btn" data-btn="MUTE">Mute</div>
+    </div>
+
+    <div class="power-btn" data-btn="POWER">&#9211;</div>
+
+    <div style="display:flex;flex-direction:column;align-items:center;gap:8px;">
+      <div class="ch-rocker">
+        <div class="ch-btn" data-btn="CHANNELUP">CH &#9650;</div>
+        <div class="vol-divider"></div>
+        <div class="ch-btn" data-btn="CHANNELDOWN">CH &#9660;</div>
+      </div>
+      <div style="height:36px;"></div>
+    </div>
+  </div>
+</div>
+
+<div class="toast" id="toast"></div>
+
+<script>
+const toast = document.getElementById('toast');
+const statusEl = document.getElementById('status');
+const statusText = document.getElementById('status-text');
+let toastTimer;
+
+function showToast(msg) {
+  toast.textContent = msg;
+  toast.classList.add('show');
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => toast.classList.remove('show'), 400);
+}
+
+async function sendBtn(name) {
+  try {
+    const r = await fetch('/api/button', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({button: name})
+    });
+    const d = await r.json();
+    if (d.ok) {
+      showToast(name);
+    } else {
+      showToast('ERR: ' + d.error);
+    }
+  } catch (e) {
+    showToast('Network error');
+  }
+}
+
+// Poll status
+async function pollStatus() {
+  try {
+    const r = await fetch('/api/status');
+    const d = await r.json();
+    statusText.textContent = d.message;
+    if (d.connected) {
+      statusEl.classList.add('connected');
+    } else {
+      statusEl.classList.remove('connected');
+    }
+  } catch (e) {
+    statusText.textContent = 'Server unreachable';
+    statusEl.classList.remove('connected');
+  }
+}
+setInterval(pollStatus, 3000);
+pollStatus();
+
+// Bind all buttons
+document.querySelectorAll('[data-btn]').forEach(el => {
+  function fire(e) {
+    e.preventDefault();
+    const btn = el.getAttribute('data-btn');
+    el.classList.add('pressing');
+    setTimeout(() => el.classList.remove('pressing'), 150);
+    // Haptic feedback if available
+    if (navigator.vibrate) navigator.vibrate(10);
+    sendBtn(btn);
+  }
+  el.addEventListener('touchstart', fire, {passive: false});
+  el.addEventListener('mousedown', fire);
+});
+</script>
+</body>
+</html>"""
+
+
+class RemoteHandler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        # Quieter logs
+        pass
+
+    def do_GET(self):
+        if self.path == "/" or self.path == "/index.html":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(HTML_PAGE.encode())
+        elif self.path == "/api/status":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(tv_status).encode())
+        else:
+            self.send_error(404)
+
+    def do_POST(self):
+        if self.path == "/api/button":
+            length = int(self.headers.get("Content-Length", 0))
+            body = json.loads(self.rfile.read(length)) if length else {}
+            button = body.get("button", "")
+            valid = {
+                "UP", "DOWN", "LEFT", "RIGHT", "ENTER",
+                "BACK", "MENU", "HOME", "INFO", "MUTE",
+                "VOLUMEUP", "VOLUMEDOWN", "CHANNELUP", "CHANNELDOWN",
+                "POWER", "PLAY", "PAUSE", "FASTFORWARD", "REWIND",
+                "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+            }
+            if button not in valid:
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"ok": False, "error": "Invalid button"}).encode())
+                return
+
+            ok, msg = send_button(button)
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"ok": ok, "error": msg if not ok else None}).encode())
+        else:
+            self.send_error(404)
+
+
+def main():
+    # Connect to TV in background
+    threading.Thread(target=connect_tv, daemon=True).start()
+    threading.Thread(target=keepalive_loop, daemon=True).start()
+
+    server = HTTPServer(("0.0.0.0", WEB_PORT), RemoteHandler)
+    print(f"LG Remote web UI: http://0.0.0.0:{WEB_PORT}")
+    print(f"Open on iPhone: http://<your-mac-ip>:{WEB_PORT}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down...")
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/lg_remote_web.py
+++ b/lg_remote_web.py
@@ -38,7 +38,10 @@ def connect_tv():
                     tv_ws.close()
                 tv_ws = WebSocketClient(TV_HOST, TV_PORT)
                 tv_ws.connect()
+                # Give user 60s to accept the pairing prompt on the TV
+                tv_ws.sock.settimeout(60)
                 authenticate(tv_ws)
+                tv_ws.sock.settimeout(10)
                 url = get_input_socket_url(tv_ws)
                 tv_input = WebSocketInputClient(url)
                 tv_input.connect()
@@ -141,14 +144,16 @@ body {
 /* Remote container */
 .remote {
   display: flex; flex-direction: column; align-items: center;
-  gap: 20px; width: 100%; max-width: 320px;
+  justify-content: space-evenly;
+  gap: 0; width: 100%; max-width: 400px;
   flex: 1;
+  padding: 0 8px;
 }
 
 /* D-Pad */
 .dpad {
   position: relative;
-  width: 220px; height: 220px;
+  width: min(72vw, 280px); height: min(72vw, 280px);
 }
 .dpad-ring {
   position: absolute; inset: 0;
@@ -159,50 +164,43 @@ body {
 .dpad-btn {
   position: absolute;
   display: flex; align-items: center; justify-content: center;
-  color: #c0c0c8; font-size: 22px;
+  color: #c0c0c8; font-size: 26px;
   cursor: pointer;
   z-index: 2;
-  transition: color 0.1s;
+  border-radius: 12px;
+  transition: background 0.1s, color 0.1s;
 }
-.dpad-btn:active { color: #fff; }
-.dpad-up    { top: 8px;   left: 50%; transform: translateX(-50%); width: 70px; height: 60px; }
-.dpad-down  { bottom: 8px; left: 50%; transform: translateX(-50%); width: 70px; height: 60px; }
-.dpad-left  { left: 8px;  top: 50%; transform: translateY(-50%); width: 60px; height: 70px; }
-.dpad-right { right: 8px; top: 50%; transform: translateY(-50%); width: 60px; height: 70px; }
+.dpad-btn:active { color: #fff; background: rgba(60, 100, 200, 0.25); }
+.dpad-up    { top: 6px;    left: 50%; transform: translateX(-50%); width: 80px; height: 72px; }
+.dpad-down  { bottom: 6px; left: 50%; transform: translateX(-50%); width: 80px; height: 72px; }
+.dpad-left  { left: 6px;   top: 50%; transform: translateY(-50%); width: 72px; height: 80px; }
+.dpad-right { right: 6px;  top: 50%; transform: translateY(-50%); width: 72px; height: 80px; }
 .dpad-ok {
   position: absolute;
   top: 50%; left: 50%; transform: translate(-50%, -50%);
-  width: 72px; height: 72px; border-radius: 50%;
+  width: 80px; height: 80px; border-radius: 50%;
   background: #222233;
   border: 1px solid #333345;
   display: flex; align-items: center; justify-content: center;
-  font-size: 15px; font-weight: 600; color: #d0d0d8;
+  font-size: 17px; font-weight: 600; color: #d0d0d8;
   cursor: pointer; z-index: 3;
   transition: background 0.1s;
 }
 .dpad-ok:active { background: #3355aa; color: #fff; }
 
-/* Touch highlight for d-pad arrows */
-.dpad-btn:active::after {
-  content: '';
-  position: absolute; inset: 0;
-  border-radius: 50%;
-  background: rgba(60, 100, 200, 0.25);
-}
-
 /* Nav row */
 .nav-row {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 10px;
-  width: 100%; max-width: 260px;
+  gap: 12px;
+  width: 100%; max-width: 340px;
 }
 .nav-btn {
-  height: 44px; border-radius: 22px;
+  height: 50px; border-radius: 25px;
   background: #1e1e28;
   border: 1px solid #2a2a35;
   color: #c0c0c8;
-  font-size: 14px; font-weight: 500;
+  font-size: 16px; font-weight: 500;
   cursor: pointer;
   transition: background 0.1s;
   display: flex; align-items: center; justify-content: center;
@@ -212,36 +210,36 @@ body {
 /* Bottom controls */
 .bottom-row {
   display: flex; align-items: center; justify-content: space-between;
-  width: 100%; max-width: 280px;
-  gap: 16px;
+  width: 100%; max-width: 340px;
+  gap: 20px;
 }
 
 /* Volume rocker */
 .vol-rocker {
   display: flex; flex-direction: column;
-  border-radius: 28px;
+  border-radius: 32px;
   background: #1a1a22;
   border: 1px solid #2a2a35;
   overflow: hidden;
-  width: 60px;
+  width: 68px;
 }
 .vol-btn {
-  height: 52px;
+  height: 58px;
   display: flex; align-items: center; justify-content: center;
-  font-size: 22px; font-weight: 600; color: #c0c0c8;
+  font-size: 24px; font-weight: 600; color: #c0c0c8;
   cursor: pointer;
   transition: background 0.1s;
 }
 .vol-btn:active { background: #3355aa; color: #fff; }
 .vol-divider {
-  height: 1px; background: #2a2a35; margin: 0 8px;
+  height: 1px; background: #2a2a35; margin: 0 10px;
 }
 
 /* Mute */
 .mute-btn {
-  width: 60px; height: 36px; border-radius: 18px;
+  width: 68px; height: 40px; border-radius: 20px;
   background: #1e1e28; border: 1px solid #2a2a35;
-  color: #c0c0c8; font-size: 12px; font-weight: 500;
+  color: #c0c0c8; font-size: 13px; font-weight: 500;
   cursor: pointer; display: flex; align-items: center; justify-content: center;
   transition: background 0.1s;
 }
@@ -249,11 +247,11 @@ body {
 
 /* Power */
 .power-btn {
-  width: 56px; height: 56px; border-radius: 50%;
+  width: 64px; height: 64px; border-radius: 50%;
   background: #3a1515;
   border: 2px solid #5a2020;
   color: #e04040;
-  font-size: 24px;
+  font-size: 28px;
   cursor: pointer;
   display: flex; align-items: center; justify-content: center;
   transition: background 0.1s;
@@ -263,16 +261,16 @@ body {
 /* Channel rocker */
 .ch-rocker {
   display: flex; flex-direction: column;
-  border-radius: 28px;
+  border-radius: 32px;
   background: #1a1a22;
   border: 1px solid #2a2a35;
   overflow: hidden;
-  width: 60px;
+  width: 68px;
 }
 .ch-btn {
-  height: 52px;
+  height: 58px;
   display: flex; align-items: center; justify-content: center;
-  font-size: 13px; font-weight: 600; color: #c0c0c8;
+  font-size: 14px; font-weight: 600; color: #c0c0c8;
   cursor: pointer;
   transition: background 0.1s;
 }
@@ -280,10 +278,10 @@ body {
 
 /* Feedback toast */
 .toast {
-  position: fixed; bottom: 40px; left: 50%; transform: translateX(-50%);
+  position: fixed; bottom: calc(40px + env(safe-area-inset-bottom)); left: 50%; transform: translateX(-50%);
   background: rgba(50, 80, 180, 0.85);
-  color: #fff; font-size: 13px; font-weight: 600;
-  padding: 6px 18px; border-radius: 20px;
+  color: #fff; font-size: 14px; font-weight: 600;
+  padding: 8px 20px; border-radius: 20px;
   opacity: 0; transition: opacity 0.15s;
   pointer-events: none;
 }
@@ -292,10 +290,10 @@ body {
 /* Haptic feedback visual */
 @keyframes press {
   0% { transform: scale(1); }
-  50% { transform: scale(0.92); }
+  50% { transform: scale(0.93); }
   100% { transform: scale(1); }
 }
-.pressing { animation: press 0.15s ease; }
+.pressing { animation: press 0.12s ease; }
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Adds Magic Remote pointer control via a trackpad zone in the floating GUI
- Click the zone to enter pointer mode — bare trackpad movement controls the TV cursor, click to select, scroll to scroll, ESC exits
- Uses CGEventTap for reliable input capture with fractional delta accumulation for smooth movement

## Implementation
- `lg_remote.py`: Added `send_move()`, `send_click()`, `send_scroll()` to `WebSocketInputClient` using SSAP text protocol
- `lg_remote_gui.py`: Modal trackpad zone with `CGAssociateMouseAndMouseCursorPosition(False)` for unbounded movement, Quartz `CGEventTap` for raw delta capture, `Sensitivity` class for sub-pixel accumulation

Closes #9

## Test plan
- [x] Pointer moves smoothly with trackpad swipes
- [x] Click sends select to TV
- [x] ESC exits pointer mode, cursor restores
- [x] Q quits app even from pointer mode
- [x] Window drag still works outside trackpad zone