### PR TITLE
Use spacebar as click in trackpad pointer mode

### DIFF
--- a/lg_remote_gui.py
+++ b/lg_remote_gui.py
@@ -856,8 +856,11 @@ class AppDelegate(NSObject):
             os._exit(0)
             return None
 
-        # In trackpad mode, don't process button keys (except ESC/Q above)
+        # In trackpad mode, spacebar = click, ignore other keys
         if self.remote_view.trackpadSelected:
+            if kc == 49:  # Space
+                self.send_pointer_click()
+                return None
             return event
 
         btn = KEYCODE_MAP.get(kc)


### PR DESCRIPTION
## Summary
- Mac cursor is hidden/frozen in pointer mode, so mouse clicks can't reliably reach the window
- Spacebar now sends a pointer click while in trackpad mode

One-line fix in the key handler.

## Test plan
- [x] Enter trackpad mode, aim, spacebar to select
- [x] Spacebar still sends MENU when not in trackpad mode